### PR TITLE
Corrections for pcm_a52 to work with pulseaudio

### DIFF
--- a/a52/pcm_a52.c
+++ b/a52/pcm_a52.c
@@ -154,6 +154,8 @@ static int write_out_pending(snd_pcm_ioplug_t *io, struct a52_ctx *rec)
 		if (err < 0) {
 			if (err == -EPIPE)
 				io->state = SND_PCM_STATE_XRUN;
+			if (err == -EAGAIN)
+				break;
 			return err;
 		} else if (! err)
 			break;
@@ -312,7 +314,7 @@ static snd_pcm_sframes_t a52_transfer(snd_pcm_ioplug_t *io,
 
 	do {
 		err = fill_data(io, areas, offset, size, interleaved);
-		if (err < 0)
+		if (err <= 0)
 			break;
 		offset += (unsigned int)err;
 		size -= (unsigned int)err;


### PR DESCRIPTION
Hi there,

First this is my first contact with ALSA programming, so please forgive me for any obvious mistakes I made.

On my computer Pulseaudio didn't work with the pcm_a52 plugin (Digital Surround 5.1 profile in Pulseaudio), everything was played with 30x speed (approximately). So I looked into the cause of this. Pulseaudio uses the zero-copy mmap interface of ALSA and expects that snd_pcm_mmap_commit() will accept all frames that snd_pcm_mmap_begin() allowed to send. If snd_pcm_mmap_commit() accepts less frames or none (-EAGAIN) then Pulseaudio didn't remember that or even saved those frames. They were just discarded.

I thought that it would be a sound contract to guarantee that snd_pcm_mmap_commit() will always take those frames. Therefore I looked into pcm_a52, why it doesn't promise that, and changed the a52_pointer() function to offer such a guarantee.

These are my patches to make it work.

Best regards,
Alex