### PR TITLE
New lavc api

### DIFF
--- a/a52/pcm_a52.c
+++ b/a52/pcm_a52.c
@@ -1004,7 +1004,9 @@ SND_PCM_PLUGIN_DEFINE_FUNC(a52)
 #ifndef USE_AVCODEC_FRAME
 	avcodec_init();
 #endif
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 0, 0)
 	avcodec_register_all();
+#endif
 
 	rec->codec = avcodec_find_encoder_by_name("ac3_fixed");
 	if (rec->codec == NULL)

--- a/a52/pcm_a52.c
+++ b/a52/pcm_a52.c
@@ -62,6 +62,12 @@
 #define AV_CODEC_ID_AC3 CODEC_ID_AC3
 #endif
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(56, 56, 0)
+#ifndef AV_INPUT_BUFFER_PADDING_SIZE
+#define AV_INPUT_BUFFER_PADDING_SIZE   FF_INPUT_BUFFER_PADDING_SIZE
+#endif
+#endif
+
 #if LIBAVCODEC_VERSION_INT < 0x371c01
 #define av_frame_alloc avcodec_alloc_frame
 #define av_frame_free avcodec_free_frame
@@ -623,9 +629,10 @@ static int a52_prepare(snd_pcm_ioplug_t *io)
 		return -EINVAL;
 
 	rec->outbuf_size = rec->avctx->frame_size * 4;
-	rec->outbuf = malloc(rec->outbuf_size);
+	rec->outbuf = malloc(rec->outbuf_size + AV_INPUT_BUFFER_PADDING_SIZE);
 	if (! rec->outbuf)
 		return -ENOMEM;
+	memset(rec->outbuf + rec->outbuf_size, 0, AV_INPUT_BUFFER_PADDING_SIZE);
 
 	if (alloc_input_buffer(io))
 		return -ENOMEM;


### PR DESCRIPTION
This is untested (I don't have access to a system with alsa, but the change was straightforward enough that i could write it).

It is unlikely that it will fix the silence issue described in #22, but it nonetheless is a change required in order to support future versions of ffmpeg.
The silence is, as far as i could tell, related to the fact that starting with ffmpeg 4.4, the ac3_fixed encoder takes S32 planar as input, versus the S16 planar it used to. This plugin should look at the AVCodec sample_fmts[0] value and feed the encoder the appropriate data.