### PR TITLE
rate-lav: Convert to libswresample

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,7 @@ AC_ARG_ENABLE([libav],
       AS_HELP_STRING([--disable-libav], [Do not build plugins depending on libav/ffmpeg (a52,lavrate...)]))
 
 if test "x$enable_libav" != "xno"; then
-  PKG_CHECK_MODULES(LIBAV, [libavcodec libavutil libavresample], [HAVE_LIBAV=yes], [HAVE_LIBAV=no])
+  PKG_CHECK_MODULES(LIBAV, [libavcodec libavutil libswresample], [HAVE_LIBAV=yes], [HAVE_LIBAV=no])
 fi
 
 if test "x$HAVE_LIBAV" = "xno"; then

--- a/doc/lavrate.txt
+++ b/doc/lavrate.txt
@@ -2,7 +2,7 @@ Rate Converter Plugin Using libavresample
 =========================================0
 
 The plugin in rate-lavr subdirectory is an external rate converter using
-libavresample library. You can use this rate converter plugin by defining a
+libswresample library. You can use this rate converter plugin by defining a
 rate PCM with "converter" parameter, such as:
 
 	pcm.my_rate {
@@ -16,7 +16,7 @@ The plug plugin has also a similar field, "rate_converter".
 Or, more easily, define a global variable "defaults.pcm.rate_converter",
 which is used as the default converter type by plug and rate plugins:
 
-	defaults.pcm.rate_converter "lavcrate"
+	defaults.pcm.rate_converter "lavrate"
 
 Write the above in your ~/.asoundrc or /etc/asound.conf.
 

--- a/rate-lav/rate_lavrate.c
+++ b/rate-lav/rate_lavrate.c
@@ -1,5 +1,5 @@
 /*
- * Rate converter plugin using libavresample
+ * Rate converter plugin using libswresample
  * Copyright (c) 2014 by Anton Khirnov
  *
  * This library is free software; you can redistribute it and/or
@@ -17,7 +17,7 @@
 #include <alsa/asoundlib.h>
 #include <alsa/pcm_rate.h>
 
-#include <libavresample/avresample.h>
+#include <libswresample/swresample.h>
 #include <libavutil/channel_layout.h>
 #include <libavutil/opt.h>
 #include <libavutil/mathematics.h>
@@ -25,11 +25,9 @@
 
 
 static unsigned int filter_size = 16;
-static unsigned int phase_shift = 10; /* auto-adjusts */
-static double cutoff = 0; /* auto-adjusts */
 
 struct rate_src {
-	AVAudioResampleContext *avr;
+	SwrContext *avr;
 
 	unsigned int in_rate;
 	unsigned int out_rate;
@@ -51,51 +49,38 @@ static snd_pcm_uframes_t output_frames(void *obj ATTRIBUTE_UNUSED,
 static void pcm_src_free(void *obj)
 {
 	struct rate_src *rate = obj;
-	avresample_free(&rate->avr);
+	swr_free(&rate->avr);
 }
 
 static int pcm_src_init(void *obj, snd_pcm_rate_info_t *info)
 {
 	struct rate_src *rate = obj;
-	int i, ir, or;
 
 	if (!rate->avr || rate->channels != info->channels) {
 		int ret;
 
 		pcm_src_free(rate);
 		rate->channels = info->channels;
-		ir = rate->in_rate = info->in.rate;
-		or = rate->out_rate = info->out.rate;
-		i = av_gcd(or, ir);
-		if (or > ir) {
-			phase_shift = or/i;
-		} else {
-			phase_shift = ir/i;
-		}
-		if (cutoff <= 0.0) {
-			cutoff = 1.0 - 1.0/filter_size;
-			if (cutoff < 0.80)
-				cutoff = 0.80;
-		}
+		rate->in_rate = info->in.rate;
+		rate->out_rate = info->out.rate;
 
-		rate->avr = avresample_alloc_context();
+		rate->avr = swr_alloc();
 		if (!rate->avr)
 			return -ENOMEM;
 
-		av_opt_set_int(rate->avr, "in_sample_rate",     info->in.rate,  0);
-		av_opt_set_int(rate->avr, "out_sample_rate",    info->out.rate, 0);
-		av_opt_set_int(rate->avr, "in_sample_format",   AV_SAMPLE_FMT_S16, 0);
-		av_opt_set_int(rate->avr, "out_sample_format",  AV_SAMPLE_FMT_S16, 0);
-		av_opt_set_int(rate->avr, "in_channel_layout",  av_get_default_channel_layout(rate->channels), 0);
-		av_opt_set_int(rate->avr, "out_channel_layout", av_get_default_channel_layout(rate->channels), 0);
+		av_opt_set_channel_layout(rate->avr, "in_channel_layout",
+					  av_get_default_channel_layout(rate->channels), 0);
+		av_opt_set_channel_layout(rate->avr, "out_channel_layout",
+					  av_get_default_channel_layout(rate->channels), 0);
+		av_opt_set_int(rate->avr, "in_sample_rate", rate->in_rate, 0);
+		av_opt_set_int(rate->avr, "out_sample_rate", rate->out_rate, 0);
+		av_opt_set_sample_fmt(rate->avr, "in_sample_fmt", AV_SAMPLE_FMT_S16, 0);
+		av_opt_set_sample_fmt(rate->avr, "out_sample_fmt", AV_SAMPLE_FMT_S16, 0);
 
-		av_opt_set_int(rate->avr, "filter_size",        filter_size, 0);
-		av_opt_set_int(rate->avr, "phase_shift",        phase_shift, 0);
-		av_opt_set_double(rate->avr, "cutoff",          cutoff,      0);
-
-		ret = avresample_open(rate->avr);
+		ret = swr_init(rate->avr);
 		if (ret < 0) {
-			avresample_free(&rate->avr);
+			SNDERR("sw_init() error %d\n", ret);
+			swr_free(&rate->avr);
 			return -EINVAL;
 		}
 	}
@@ -118,8 +103,8 @@ static void pcm_src_reset(void *obj)
 
 	if (rate->avr) {
 #if 0
-		avresample_close(rate->avr);
-		avresample_open(rate->avr);
+		swr_free(rate->avr);
+		swr_init(rate->avr);
 #endif
 	}
 }
@@ -130,14 +115,14 @@ static void pcm_src_convert_s16(void *obj, int16_t *dst,
 				unsigned int src_frames)
 {
 	struct rate_src *rate = obj;
-	int chans = rate->channels;
-	unsigned int total_in = avresample_get_delay(rate->avr) + src_frames;
+	unsigned int total_in = swr_get_delay(rate->avr, rate->in_rate) + src_frames;
 
-	avresample_convert(rate->avr, (uint8_t **)&dst, dst_frames * chans * 2, dst_frames,
-	                   (uint8_t **)&src, src_frames * chans * 2, src_frames);
+	swr_convert(rate->avr, (uint8_t **)&dst, dst_frames,
+		    (const uint8_t **)&src, src_frames);
 
-	avresample_set_compensation(rate->avr,
-                                    total_in - src_frames > filter_size ? 0 : 1, src_frames);
+	swr_set_compensation(rate->avr,
+			     total_in - src_frames > filter_size ? 0 : 1,
+			     src_frames);
 }
 
 static void pcm_src_close(void *obj)
@@ -156,7 +141,7 @@ static int get_supported_rates(void *obj ATTRIBUTE_UNUSED,
 
 static void dump(void *obj ATTRIBUTE_UNUSED, snd_output_t *out)
 {
-	snd_output_printf(out, "Converter: libavr\n");
+	snd_output_printf(out, "Converter: libswresample\n");
 }
 #endif
 
@@ -177,7 +162,6 @@ static snd_pcm_rate_ops_t pcm_src_ops = {
 };
 
 int pcm_src_open(unsigned int version, void **objp, snd_pcm_rate_ops_t *ops)
-
 {
 	struct rate_src *rate;
 


### PR DESCRIPTION
The libavresample has been deprecated.  Convert to the new API for
libswresample.

The phase shift and cutoff seem to be either redundant or not-working
properly, so those are dropped.

Signed-off-by: Takashi Iwai <tiwai@suse.de>