### PR TITLE
arcam_av.c: Include missing string.h

### DIFF
--- a/arcam-av/arcam_av.c
+++ b/arcam-av/arcam_av.c
@@ -27,6 +27,7 @@
 #include <signal.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
 #include <termios.h>
 #include <unistd.h>
 


### PR DESCRIPTION
bzero() function needs this header to be included

Signed-off-by: Khem Raj <raj.khem@gmail.com>