### PR TITLE
OpenBSD (and maybe other *BSDs) support

### DIFF
--- a/a52/pcm_a52.c
+++ b/a52/pcm_a52.c
@@ -28,6 +28,10 @@
 #include <libavcodec/avcodec.h>
 #include <libavutil/avutil.h>
 
+#ifndef ESTRPIPE
+#define ESTRPIPE EPIPE
+#endif
+
 /* some compatibility wrappers */
 #ifndef AV_VERSION_INT
 #define AV_VERSION_INT(a, b, c) (((a) << 16) | ((b) << 8) | (c))

--- a/a52/pcm_a52.c
+++ b/a52/pcm_a52.c
@@ -29,7 +29,7 @@
 #include <libavutil/avutil.h>
 
 #ifndef ESTRPIPE
-#define ESTRPIPE EPIPE
+#define ESTRPIPE ESPIPE
 #endif
 
 /* some compatibility wrappers */

--- a/configure.ac
+++ b/configure.ac
@@ -17,14 +17,25 @@ AC_HEADER_STDC
 CC_NOUNDEFINED
 
 PKG_CHECK_MODULES(ALSA, alsa >= 1.1.6)
-AC_CHECK_LIB(asound, snd_pcm_ioplug_create,,
+case $host_os in
+netbsd* | freebsd* | dragonfly* | openbsd*)
+  AC_CHECK_LIB(asound, snd_pcm_ioplug_create,,
+	     AC_ERROR([*** libasound has no external plugin SDK]))
+  ;;
+*)
+  AC_CHECK_LIB(asound, snd_pcm_ioplug_create,,
 	     AC_ERROR([*** libasound has no external plugin SDK]), -ldl)
+  ;;
+esac
 
 AC_ARG_ENABLE([oss],
       AS_HELP_STRING([--disable-oss], [Disable building of OSS plugin]))
-AS_IF([test "x$enable_oss" != "xno"],
-      [AM_CONDITIONAL(HAVE_OSS, true)],
-      [AM_CONDITIONAL(HAVE_OSS, false)])
+if test "x$enable_oss" != "xno"; then
+      AM_CONDITIONAL(HAVE_OSS, true)
+      AC_CHECK_HEADERS([sys/soundcard.h soundcard.h])
+else
+      AM_CONDITIONAL(HAVE_OSS, false)
+fi
 
 AC_ARG_ENABLE([mix],
       AS_HELP_STRING([--disable-mix], [Disable building of upmix and vdownmix plugins]))

--- a/jack/pcm_jack.c
+++ b/jack/pcm_jack.c
@@ -23,7 +23,6 @@
 #define _GNU_SOURCE
 #include <stdbool.h>
 #include <errno.h>
-#include <byteswap.h>
 #include <sys/shm.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -603,7 +602,11 @@ static int snd_pcm_jack_open(snd_pcm_t **pcmp, const char *name,
 	}
 
 	if (client_name == NULL) {
+#if defined(__linux__)
 		const char *pname = program_invocation_short_name;
+#else
+		const char *pname = getprogname();
+#endif
 		if (!pname[0]) {
 			pname = "alsa-jack";
 		}

--- a/jack/pcm_jack.c
+++ b/jack/pcm_jack.c
@@ -602,7 +602,7 @@ static int snd_pcm_jack_open(snd_pcm_t **pcmp, const char *name,
 	}
 
 	if (client_name == NULL) {
-#if defined(__linux__)
+#if defined(_GNU_SOURCE)
 		const char *pname = program_invocation_short_name;
 #else
 		const char *pname = getprogname();

--- a/oss/ctl_oss.c
+++ b/oss/ctl_oss.c
@@ -22,11 +22,18 @@
  * TODO: implement the pseudo poll with thread (and pipe as pollfd)?
  */
 
+#include "config.h"
 #include <stdio.h>
 #include <sys/ioctl.h>
 #include <alsa/asoundlib.h>
 #include <alsa/control_external.h>
+#if defined(__linux__)
 #include <linux/soundcard.h>
+#elif HAVE_SYS_SOUNDCARD_H
+#include <sys/soundcard.h>
+#elif HAVE_SOUNDCARD_H
+#include <soundcard.h>
+#endif
 
 typedef struct snd_ctl_oss {
 	snd_ctl_ext_t ext;

--- a/oss/pcm_oss.c
+++ b/oss/pcm_oss.c
@@ -18,11 +18,18 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "config.h"
 #include <stdio.h>
 #include <sys/ioctl.h>
 #include <alsa/asoundlib.h>
 #include <alsa/pcm_external.h>
+#if defined(__linux__)
 #include <linux/soundcard.h>
+#elif HAVE_SYS_SOUNDCARD_H
+#include <sys/soundcard.h>
+#elif HAVE_SOUNDCARD_H
+#include <soundcard.h>
+#endif
 
 typedef struct snd_pcm_oss {
 	snd_pcm_ioplug_t io;

--- a/pulse/pulse.h
+++ b/pulse/pulse.h
@@ -24,6 +24,10 @@
 
 #include <pulse/pulseaudio.h>
 
+#ifndef EBADFD
+#define EBADFD EBADF
+#endif
+
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof((a)[0]))
 
 typedef struct snd_pulse {

--- a/usb_stream/pcm_usb_stream.c
+++ b/usb_stream/pcm_usb_stream.c
@@ -19,7 +19,6 @@
  */
 
 #define _GNU_SOURCE
-#include <byteswap.h>
 #include <sys/mman.h>
 #include <sys/shm.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
fix some compile errors and build test on OpenBSD/NetBSD.
aaf, arcam-av, maemo and usb_stream is not supported for non-Linux environment.